### PR TITLE
Improve face similarity processing

### DIFF
--- a/01_face_detection_cropping.py
+++ b/01_face_detection_cropping.py
@@ -96,7 +96,8 @@ class Aligner:
         LOG.info("Using CPU (1024×1024)")
 
     def detect(self, img_bgr: np.ndarray):
-        return self.det.get(cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB), max_num=0)
+        """Detect faces in a BGR image using RetinaFace."""
+        return self.det.get(img_bgr, max_num=0)
 
     @staticmethod
     def crop(img_bgr: np.ndarray, kps5: np.ndarray) -> np.ndarray:

--- a/02_embedding_vectorization.py
+++ b/02_embedding_vectorization.py
@@ -178,11 +178,13 @@ def aligned_crop(meta: Dict[str,Any]) -> np.ndarray | None:
     return cv2.imread(meta["cropped_face"])
 
 def embed_face(img_bgr: np.ndarray) -> np.ndarray | None:
+    """Return flip-augmented ArcFace embedding for a BGR crop."""
     if img_bgr is None or img_bgr.size == 0:
         return None
-    rgb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB)
-    v1  = _ARCFACE.get_feat(rgb).astype(np.float32).ravel()
-    v2  = _ARCFACE.get_feat(rgb[:, ::-1, :]).astype(np.float32).ravel()
+    face = cv2.resize(img_bgr, (112, 112)) if img_bgr.shape[:2] != (112, 112) else img_bgr
+    v1  = _ARCFACE.get_feat(face).astype(np.float32).ravel()
+    flip = cv2.flip(face, 1)
+    v2  = _ARCFACE.get_feat(flip).astype(np.float32).ravel()
     vec = v1 + v2
     vec /= (np.linalg.norm(vec) + 1e-7)
     return vec

--- a/face_ingest.py
+++ b/face_ingest.py
@@ -52,7 +52,7 @@ def embed_faces(img_path: str):
     out = []
     for box in boxes:
         x1, y1, x2, y2 = map(int, box)
-        crop = rgb[y1:y2, x1:x2]
+        crop = bgr[y1:y2, x1:x2]
         if crop.size == 0:
             continue
         crop = cv2.resize(crop, (112, 112))


### PR DESCRIPTION
## Summary
- use BGR images directly for detection and embedding
- return flip-augmented embeddings
- remove unnecessary RGB conversions across scripts
- adapt ingestion, API and embedding scripts accordingly

## Testing
- `python -m py_compile 04_query_similarity_search.py`
- `python -m py_compile 01_face_detection_cropping.py 02_embedding_vectorization.py api_server_simple.py face_ingest.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68749e17033083309d19ab0b416361ba