### PR TITLE
Allow external static roots and remove Google font fetch

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -95,13 +95,18 @@ async def search_image(
 
 @app.get("/api/static", response_class=FileResponse, summary="Serve safe static files")
 def serve_static(path: str):
-    """
-    Only files within *cropped_faces* or *dataset* are allowed.
-    """
+    """Serve files from a whitelist of directories."""
     allowed_roots: List[Path] = [
         (HERE / "cropped_faces").resolve(),
-        (HERE / "dataset").resolve()
+        (HERE / "dataset").resolve(),
     ]
+
+    extra = os.getenv("EXTRA_STATIC_ROOTS")
+    if extra:
+        for r in extra.split(os.pathsep):
+            if r:
+                allowed_roots.append(Path(r).resolve())
+
     abs_path = Path(path).resolve()
     if not any(abs_path.is_relative_to(root) for root in allowed_roots):
         return JSONResponse(status_code=403, content={"error": "Forbidden"})

--- a/api_server_fixed.py
+++ b/api_server_fixed.py
@@ -146,13 +146,18 @@ async def search_image(
 
 @app.get("/api/static", response_class=FileResponse, summary="Serve safe static files")
 def serve_static(path: str):
-    """
-    Only files within *cropped_faces* or *dataset* are allowed.
-    """
+    """Serve files from allowed directories only."""
     allowed_roots: List[Path] = [
         (HERE / "cropped_faces").resolve(),
-        (HERE / "dataset").resolve()
+        (HERE / "dataset").resolve(),
     ]
+
+    extra = os.getenv("EXTRA_STATIC_ROOTS")
+    if extra:
+        for r in extra.split(os.pathsep):
+            if r:
+                allowed_roots.append(Path(r).resolve())
+
     abs_path = Path(path).resolve()
     if not any(abs_path.is_relative_to(root) for root in allowed_roots):
         return JSONResponse(status_code=403, content={"error": "Forbidden"})

--- a/api_server_simple.py
+++ b/api_server_simple.py
@@ -169,8 +169,18 @@ def health():
 
 @app.get("/api/static", response_class=FileResponse)
 def serve_static(path: str):
-    allowed = [(ROOT_DIR / "cropped_faces").resolve(),
-               (ROOT_DIR / "dataset").resolve()]
+    """Serve images only from explicitly allowed directories."""
+    allowed = [
+        (ROOT_DIR / "cropped_faces").resolve(),
+        (ROOT_DIR / "dataset").resolve(),
+    ]
+
+    extra = os.getenv("EXTRA_STATIC_ROOTS")
+    if extra:
+        for root in extra.split(os.pathsep):
+            if root:
+                allowed.append(Path(root).resolve())
+
     p = Path(path).resolve()
     if not any(p.is_relative_to(root) for root in allowed):
         return JSONResponse(status_code=403, content={"error": "Forbidden"})

--- a/facefindr/app/api/image-proxy/route.ts
+++ b/facefindr/app/api/image-proxy/route.ts
@@ -10,7 +10,8 @@ export async function GET(req: NextRequest) {
   const backendUrl = `http://localhost:8000/api/static?path=${encodeURIComponent(path)}`
   const resp = await fetch(backendUrl)
   if (!resp.ok) {
-    return new NextResponse('Image not found', { status: 404 })
+    const status = resp.status === 403 ? 403 : 404
+    return new NextResponse('Image not found', { status })
   }
   const contentType = resp.headers.get('content-type') || 'image/jpeg'
   const arrayBuffer = await resp.arrayBuffer()

--- a/facefindr/app/globals.css
+++ b/facefindr/app/globals.css
@@ -3,8 +3,9 @@
 @tailwind utilities;
 
 :root {
-  --font-inter: "Inter", sans-serif;
-  --font-playfair: "Playfair Display", serif;
+  /* Use system fonts to avoid remote fetches */
+  --font-inter: ui-sans-serif, system-ui, sans-serif;
+  --font-playfair: ui-serif, Georgia, serif;
 }
 
 @layer base {

--- a/facefindr/app/layout.tsx
+++ b/facefindr/app/layout.tsx
@@ -1,18 +1,9 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Inter, Playfair_Display } from "next/font/google"
 import "./globals.css"
 
-const inter = Inter({
-  subsets: ["latin"],
-  variable: "--font-inter",
-})
-
-const playfair = Playfair_Display({
-  subsets: ["latin"],
-  variable: "--font-playfair",
-  weight: ["400", "600", "700"],
-})
+// Use system fonts to avoid fetching from Google Fonts
+const fontClasses = "font-sans antialiased"
 
 export const metadata: Metadata = {
   title: "FaceFindr - Find every photo of that face",
@@ -27,7 +18,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${inter.variable} ${playfair.variable} font-sans antialiased`}>{children}</body>
+      <body className={fontClasses}>{children}</body>
     </html>
   )
 }

--- a/facefindr/app/search/page.tsx
+++ b/facefindr/app/search/page.tsx
@@ -79,9 +79,9 @@ export default function SearchPage() {
             similarity = Math.round(similarity * 10) / 10;
           }
           // Pass bbox from match if available
-          let bbox = undefined;
-          if (Array.isArray(m.bbox_x1) && m.bbox_x1.length === 4) {
-            bbox = m.bbox_x1;
+          let bbox: number[] | undefined = undefined;
+          if (Array.isArray((m as any).bbox) && (m as any).bbox.length === 4) {
+            bbox = (m as any).bbox as number[];
           } else if (
             typeof m.bbox_x1 === "number" &&
             typeof m.bbox_y1 === "number" &&


### PR DESCRIPTION
## Summary
- allow extra directories for static file serving in API
- handle 403 vs 404 in Next.js image proxy
- drop Google font imports and use system fonts
- adapt font variables in global CSS
- fix bounding box extraction logic

## Testing
- `python -m py_compile api_server_simple.py api_server.py api_server_fixed.py`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874c68d54148330a7405ab178bbc4d2