### PR TITLE
Fix static file access for thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,14 @@ END;
    DETECTION_CONFIDENCE = 0.5  # Lower for more faces
    ```
 
+5. **Thumbnails return 403**
+   ```bash
+   # Allow your cropped_faces directory
+   set CROPPED_FACES_DIR=C:\path\to\face\cropped_faces
+   # or
+   set EXTRA_STATIC_ROOTS=C:\path\to\face\cropped_faces
+   ```
+
 ### Logging
 All scripts generate detailed logs in the `logs/` directory:
 - `face_detection_YYYYMMDD_HHMMSS.log`

--- a/api_server.py
+++ b/api_server.py
@@ -107,6 +107,24 @@ def serve_static(path: str):
             if r:
                 allowed_roots.append(Path(r).resolve())
 
+    crop_env = os.getenv("CROPPED_FACES_DIR")
+    if crop_env:
+        allowed_roots.append(Path(crop_env).resolve())
+    else:
+        meta_csv = HERE / "face_metadata.csv"
+        if meta_csv.exists():
+            try:
+                import csv
+                with meta_csv.open(newline="", encoding="utf-8") as fh:
+                    reader = csv.reader(fh)
+                    next(reader, None)
+                    for row in reader:
+                        if len(row) >= 2:
+                            allowed_roots.append(Path(row[1]).resolve().parent)
+                            break
+            except Exception:
+                pass
+
     abs_path = Path(path).resolve()
     if not any(abs_path.is_relative_to(root) for root in allowed_roots):
         return JSONResponse(status_code=403, content={"error": "Forbidden"})

--- a/api_server_fixed.py
+++ b/api_server_fixed.py
@@ -158,6 +158,24 @@ def serve_static(path: str):
             if r:
                 allowed_roots.append(Path(r).resolve())
 
+    crop_env = os.getenv("CROPPED_FACES_DIR")
+    if crop_env:
+        allowed_roots.append(Path(crop_env).resolve())
+    else:
+        meta_csv = HERE / "face_metadata.csv"
+        if meta_csv.exists():
+            try:
+                import csv
+                with meta_csv.open(newline="", encoding="utf-8") as fh:
+                    reader = csv.reader(fh)
+                    next(reader, None)
+                    for row in reader:
+                        if len(row) >= 2:
+                            allowed_roots.append(Path(row[1]).resolve().parent)
+                            break
+            except Exception:
+                pass
+
     abs_path = Path(path).resolve()
     if not any(abs_path.is_relative_to(root) for root in allowed_roots):
         return JSONResponse(status_code=403, content={"error": "Forbidden"})

--- a/api_server_simple.py
+++ b/api_server_simple.py
@@ -181,6 +181,24 @@ def serve_static(path: str):
             if root:
                 allowed.append(Path(root).resolve())
 
+    crop_env = os.getenv("CROPPED_FACES_DIR")
+    if crop_env:
+        allowed.append(Path(crop_env).resolve())
+    else:
+        meta_csv = ROOT_DIR / "face_metadata.csv"
+        if meta_csv.exists():
+            try:
+                import csv
+                with meta_csv.open(newline="", encoding="utf-8") as fh:
+                    reader = csv.reader(fh)
+                    next(reader, None)
+                    for row in reader:
+                        if len(row) >= 2:
+                            allowed.append(Path(row[1]).resolve().parent)
+                            break
+            except Exception:
+                pass
+
     p = Path(path).resolve()
     if not any(p.is_relative_to(root) for root in allowed):
         return JSONResponse(status_code=403, content={"error": "Forbidden"})


### PR DESCRIPTION
## Summary
- auto-detect cropped_faces directory for serving thumbnails
- document setting `CROPPED_FACES_DIR` for 403 errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874c9a277948330864010e82cc4748c