### PR TITLE
Fix static image access

### DIFF
--- a/api_server_fixed.py
+++ b/api_server_fixed.py
@@ -172,7 +172,9 @@ def serve_static(path: str):
                     for row in reader:
                         if len(row) >= 2:
                             allowed_roots.append(Path(row[1]).resolve().parent)
-                            break
+                        if len(row) >= 1:
+                            allowed_roots.append(Path(row[0]).resolve().parent)
+                        break
             except Exception:
                 pass
 

--- a/api_server_simple.py
+++ b/api_server_simple.py
@@ -195,7 +195,9 @@ def serve_static(path: str):
                     for row in reader:
                         if len(row) >= 2:
                             allowed.append(Path(row[1]).resolve().parent)
-                            break
+                        if len(row) >= 1:
+                            allowed.append(Path(row[0]).resolve().parent)
+                        break
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- expand allowed directories when serving static images
- include dataset image directories using info from `face_metadata.csv`

## Testing
- `python test_backend.py` *(fails: No module named 'oracledb')*
- `python test_oracle_connection.py` *(fails: No module named 'oracledb')*
- `python test_pipeline.py` *(fails: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6874cd164a548330b1082bf857b10073