### PR TITLE
Update similarity threshold to 70%

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ DETECTION_CONFIDENCE = 0.8
 FACE_SIZE = (112, 112)
 
 # Similarity search
-SIMILARITY_THRESHOLD = 0.6
+SIMILARITY_THRESHOLD = 0.7
 TOP_K_RESULTS = 50
 ```
 
@@ -305,7 +305,7 @@ Upload an image and search for similar faces.
 ```bash
 curl -X POST "http://localhost:8000/api/face-search" \
   -F "file=@query_image.jpg" \
-  -F "similarity_threshold=0.6" \
+  -F "similarity_threshold=0.7" \
   -F "top_k=50"
 ```
 

--- a/facefindr/components/results-gallery.tsx
+++ b/facefindr/components/results-gallery.tsx
@@ -18,7 +18,7 @@ interface ResultsGalleryProps {
 export default function ResultsGallery({ results, isComplete, onReset }: ResultsGalleryProps) {
   const [selectedResult, setSelectedResult] = useState<SearchResult | null>(null)
   const [showFilters, setShowFilters] = useState(false)
-  const [similarityThreshold, setSimilarityThreshold] = useState(60)
+  const [similarityThreshold, setSimilarityThreshold] = useState(70)
 
   const filteredResults = results.filter((result) => result.similarity >= similarityThreshold)
 


### PR DESCRIPTION
## Summary
- bump default similarity threshold to 70% in README and UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68773618ff6483308782555982cd5e7e